### PR TITLE
fix repository links

### DIFF
--- a/development.html
+++ b/development.html
@@ -57,7 +57,7 @@ you're expected to: <ol>
 
 <article>
 <header><h2><a id="source-code"></a>Get the Source code</h2><header>
-<p>Our git repository home page can be found on its <a href="https://github.com/spaetz/offlineimap">github home</a>. Grab the current code with a <tt>git clone git://github.com/spaetz/offlineimap.git</tt>.</p>
+<p>Our git repository home page can be found on its <a href="https://github.com/OfflineIMAP/offlineimap">github home</a>. Grab the current code with a <tt>git clone git://github.com/OfflineIMAP/offlineimap.git</tt>.</p>
 
 There are several branches. <emph>Master<emph> represents the current stable branch or what will be the next stable release. <emph>Next<emph> is where development happens. This is what will be merged into Master for the next major release. Finally <emph>PU<emph> is a feature branch which hosts crazy features that might or might not make it into some release. This branch could easily be reset at any point in time.
 </article>


### PR DESCRIPTION
On the development page, the repository links were pointing to a github repo that wasn't updated for two years...
